### PR TITLE
fix: libs conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests~=2.32.3
 pydantic~=2.10.0
 pydantic_settings~=2.2.1
-aiogram~=3.15.0
+aiogram~=3.17.0
 beautifulsoup4~=4.12.3
 emoji~=2.14.0


### PR DESCRIPTION
reported issue by python:

```
The conflict is caused by:
    The user requested pydantic~=2.10.0
    pydantic-settings 2.2.1 depends on pydantic>=2.3.0
    aiogram 3.15.0 depends on pydantic<2.10 and >=2.4.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```